### PR TITLE
Datepicker + Button in Main

### DIFF
--- a/Boule_de_Crystal/lib/theme_astral/astral_theme_page.dart
+++ b/Boule_de_Crystal/lib/theme_astral/astral_theme_page.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/material.dart';
+import 'package:calendar_date_picker2/calendar_date_picker2.dart';
+
+class ThemeAstralPage extends StatefulWidget {
+  const ThemeAstralPage({super.key});
+
+  @override
+  State<ThemeAstralPage> createState() => _ThemeAstralPageState();
+}
+
+class _ThemeAstralPageState extends State<ThemeAstralPage> {
+  List<DateTime?> _selectedDates = [null];
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Calculer un thème astral'),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text(
+              'Sélectionnez votre date de naissance',
+              style: TextStyle(fontSize: 16.0),
+            ),
+            const SizedBox(height: 16),
+            CalendarDatePicker2(
+              config: CalendarDatePicker2Config(
+                calendarType: CalendarDatePicker2Type.single,
+              ),
+              value: _selectedDates,
+              onValueChanged: (dates) {
+                setState(() {
+                  _selectedDates = dates;
+                });
+              },
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: _calculate,
+              child: const Text('Calculer'),
+            ),
+            if (_selectedDates.isNotEmpty && _selectedDates[0] != null)
+              Padding(
+                padding: const EdgeInsets.only(top: 16.0),
+                child: Text(
+                  'Date de naissance sélectionnée : ${_selectedDates[0]!.toLocal().toString().split(' ')[0]}',
+                  style: const TextStyle(fontSize: 16.0, fontWeight: FontWeight.bold),
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _calculate() {
+    if (_selectedDates.isNotEmpty && _selectedDates[0] != null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            'Votre thème astral pour la date de naissance sélectionnée : ${_selectedDates[0]!.toLocal().toString().split(' ')[0]}',
+          ),
+        ),
+      );
+    } else {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Veuillez sélectionner une date de naissance.'),
+        ),
+      );
+    }
+  }
+}


### PR DESCRIPTION
Création d'une nouvelle page pour le calcul de thème astral, avec un Datepicker (utilisation du Datepicker dans material.dart et non pas une dépendance de pub.dev) et affichage de cette date, en attendant la construction et l'utilisation de la Base de Données.

Ajout d'un bouton sur la MainPage pour naviguer vers la nouvelle page et utiliser la nouvelle fonctionnalité.

La dépendance et le package du premier DatePicker ont été laissé mais à voir dans le futur si ils sont seront supprimés.